### PR TITLE
Performance/Unit Testing for Constituents of NamedMatrix Extractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SRCDIR=src
 BINDIR=target
 MODULES=-M$(CDO_HOME)/src -M$(NUMSUCH_HOME)/src -M$(CHARCOAL_HOME)/src -M$(CHINGON_HOME)/src
 EXEC=cdoExtras
+DB_CREDS=../db_creds.txt
 
 default: all
 
@@ -17,5 +18,5 @@ run:
 
 run-test: test/CdoExtrasTest.chpl
 	$(CC) $(INCLUDES) $(LIBS) $(MODULES) -M$(SRCDIR) -o test/test $< ; \
-	./test/test -f test/db_creds.txt ; \
+	./test/test -f $(DB_CREDS) ; \
 	rm test/test

--- a/src/CdoExtras.chpl
+++ b/src/CdoExtras.chpl
@@ -28,6 +28,18 @@ module CdoExtras {
   }
 }
 
+/*
+SELECT ftr, t
+FROM (
+  SELECT distinct(source_cui) AS ftr, 'r' AS t FROM r.cui_confabulation
+  UNION ALL
+  SELECT distinct(exhibited_cui) AS ftr, 'c' AS t FROM r.cui_confabulation
+) AS a
+GROUP BY ftr, t
+ORDER BY ftr, t ;
+*/
+
+
 proc NamedMatrixFromPGRectangular(con: Connection
   , edgeTable: string
   , fromField: string, toField: string, wField: string = "NONE") {

--- a/test/CdoExtrasTest.chpl
+++ b/test/CdoExtrasTest.chpl
@@ -147,7 +147,25 @@ class CdoExtrasTest : UnitTest {
     SD.bulkAdd(indices1);
     t13.stop();
     writeln("Time to bulkAdd Indices (~10^6) to Sparse Domain: ",t13.elapsed());
-    
+
+    var t14: Timer;
+    t14.start();
+    for (i,j) in indices {
+      X(i,j) = 1;
+    }
+    t14.stop();
+    writeln("Time to Graft Ones on to Base Matrix: ",t14.elapsed());
+
+
+    var t15: Timer;
+    t15.start();
+    var nm = new NamedMatrix(X=X);
+    nm.rows = rows;
+    nm.cols = rows;
+    t15.stop();
+    writeln("Promoting X to NamedMatrix: ",t15.elapsed());
+
+
     /*
     var t1: Timer;
     t1.start();

--- a/test/CdoExtrasTest.chpl
+++ b/test/CdoExtrasTest.chpl
@@ -25,8 +25,12 @@ class CdoExtrasTest : UnitTest {
     var edgeTable = "r.cui_confabulation",
         fromField = "source_cui",
         toField = "exhibited_cui";
-
+    var t: Timer;
+    t.start();
     var con = PgConnectionFactory(host=DB_HOST, user=DB_USER, database=DB_NAME, passwd=DB_PWD);
+    t.stop();
+    writeln("Time to Establish Connection to the DB: ",t.elapsed());
+    /*
     var t1: Timer;
     t1.start();
     var nm = NamedMatrixFromPGSquare(con=con, edgeTable=edgeTable, fromField=fromField
@@ -35,7 +39,7 @@ class CdoExtrasTest : UnitTest {
 
     writeln("Dimensions are: ",nm.D);
     writeln("Time Elapsed to Load Matrix: ",t1.elapsed());
-/*
+
     var g = new Graph(nm);
 
     var t2: Timer;

--- a/test/CdoExtrasTest.chpl
+++ b/test/CdoExtrasTest.chpl
@@ -30,6 +30,36 @@ class CdoExtrasTest : UnitTest {
     var con = PgConnectionFactory(host=DB_HOST, user=DB_USER, database=DB_NAME, passwd=DB_PWD);
     t.stop();
     writeln("Time to Establish Connection to the DB: ",t.elapsed());
+
+    var t1: Timer;
+    t1.start();
+    var cursor = con.cursor();
+    t1.stop();
+    writeln("Time to Create Cursor: ",t1.elapsed());
+
+    var q = """
+    SELECT ftr
+    FROM (
+      SELECT distinct(source_cui) AS ftr FROM r.cui_confabulation
+      UNION ALL
+      SELECT distinct(exhibited_cui) AS ftr FROM r.cui_confabulation
+    ) AS a
+    GROUP BY ftr ORDER BY ftr;
+    """;
+
+    var t2: Timer;
+    t2.start();
+    var rows: BiMap = new BiMap();
+    t2.stop();
+    writeln("Time to Initialize Rows BiMap: ",t2.elapsed());
+
+    var t3: Timer;
+    t3.start();
+    cursor.query(q);
+    t3.stop();
+    writeln("Time to Query the DB: ",t3.elapsed());
+
+
     /*
     var t1: Timer;
     t1.start();

--- a/test/CdoExtrasTest.chpl
+++ b/test/CdoExtrasTest.chpl
@@ -59,6 +59,44 @@ class CdoExtrasTest : UnitTest {
     t3.stop();
     writeln("Time to Query the DB: ",t3.elapsed());
 
+    var t4: Timer;
+    t4.start();
+    for row in cursor {
+      rows.add(row['ftr']);
+    }
+    t4.stop();
+    writeln("Time to Populate Rows BiMap: ",t4.elapsed());
+
+    var t5: Timer;
+    t5.start();
+    var size = rows.size();
+    t5.stop();
+    writeln("Time to Measure Length of Row BiMap: ",t5.elapsed());
+
+    var t6: Timer;
+    t6.start();
+    var D: domain(2) = {1..rows.size(), 1..rows.size()},
+        SD = CSRDomain(D),
+        X: [SD] real;
+    t6.stop();
+    writeln("Time to Initialize Base Matrix: ",t6.elapsed());
+
+    var r = """
+    SELECT source_cui, exhibited_cui
+    FROM r.cui_confabulation
+    ORDER BY source_cui, exhibited_cui ;
+    """;
+
+
+    var cursor2 = con.cursor();
+    var t7: Timer;
+    t7.start();
+    cursor2.query(r);
+    t7.stop();
+    writeln("Time for Second DB Query: ",t7.elapsed());
+
+
+
 
     /*
     var t1: Timer;

--- a/test/CdoExtrasTest.chpl
+++ b/test/CdoExtrasTest.chpl
@@ -96,8 +96,58 @@ class CdoExtrasTest : UnitTest {
     writeln("Time for Second DB Query: ",t7.elapsed());
 
 
+    var t8: Timer;
+    t8.start();
+    var dom1: domain(1) = {1..0},
+        dom2: domain(1) = {1..0},
+        indices: [dom1] (int, int),
+        values: [dom2] real;
+    t8.stop();
+    writeln("Time to Initialize Id/Val Arrays: ",t8.elapsed());
+
+    var t9: Timer;
+    t9.start();
+    for row in cursor2 {
+      indices.push_back((rows.get(row['source_cui']),rows.get(row['exhibited_cui'])));
+    }
+    t9.stop();
+    writeln("Time to Push Back on Indices: ",t9.elapsed());
 
 
+
+    var t10: Timer;
+    t10.start();
+    const size1 = cursor2.rowcount(): int;
+    t10.stop();
+    writeln("Cursor Length Read Time: ",t10.elapsed());
+
+    var t11: Timer;
+    t11.start();
+    var count = 0: int,
+        dom = {1..size1},
+        indices1: [dom] (int, int),
+        values1: [dom] real;
+    t11.stop();
+    writeln("Index/Value Array Initialization Time: ",t11.elapsed());
+
+    var t12: Timer;
+    t12.start();
+    for row in cursor2 {
+      count += 1;
+      indices1[count]=(
+         rows.get(row['source_cui'])
+        ,rows.get(row['exhibited_cui'])
+        );
+      }
+    t12.stop();
+    writeln("Time to Graft Indices: ",t12.elapsed());
+
+    var t13: Timer;
+    t13.start();
+    SD.bulkAdd(indices1);
+    t13.stop();
+    writeln("Time to bulkAdd Indices (~10^6) to Sparse Domain: ",t13.elapsed());
+    
     /*
     var t1: Timer;
     t1.start();


### PR DESCRIPTION
Timed all of the components of `NamedMatrixFromPGSquare` to see why the process takes so long to run. Firstly, as a bonus, I found that `push_back` for building the `indices` array is almost an order slower than grafting/slicing. Secondly, from the point of initiating a db connection through building the full base matrix `X`, only about 25s is spent; with no constituent processes taking much longer than one would expect.

Once said base matrix has been built, however, promoting it to the `NamedMatrix` class takes an exorbitant amount of time. As such, we can conclude that either we are taking the wrong approach in building the matrix -> then promoting it, or there are other fundamental problems with how we construct `NamedMatrix`. 

For reference, the relevant test and output is copied below.

````
  proc testBuildNamedMatrix() {
    var edgeTable = "r.cui_confabulation",
        fromField = "source_cui",
        toField = "exhibited_cui";
    var t: Timer;
    t.start();
    var con = PgConnectionFactory(host=DB_HOST, user=DB_USER, database=DB_NAME, passwd=DB_PWD);
    t.stop();
    writeln("Time to Establish Connection to the DB: ",t.elapsed());

    var t1: Timer;
    t1.start();
    var cursor = con.cursor();
    t1.stop();
    writeln("Time to Create Cursor: ",t1.elapsed());

    var q = """
    SELECT ftr
    FROM (
      SELECT distinct(source_cui) AS ftr FROM r.cui_confabulation
      UNION ALL
      SELECT distinct(exhibited_cui) AS ftr FROM r.cui_confabulation
    ) AS a
    GROUP BY ftr ORDER BY ftr;
    """;

    var t2: Timer;
    t2.start();
    var rows: BiMap = new BiMap();
    t2.stop();
    writeln("Time to Initialize Rows BiMap: ",t2.elapsed());

    var t3: Timer;
    t3.start();
    cursor.query(q);
    t3.stop();
    writeln("Time to Query the DB: ",t3.elapsed());

    var t4: Timer;
    t4.start();
    for row in cursor {
      rows.add(row['ftr']);
    }
    t4.stop();
    writeln("Time to Populate Rows BiMap: ",t4.elapsed());

    var t5: Timer;
    t5.start();
    var size = rows.size();
    t5.stop();
    writeln("Time to Measure Length of Row BiMap: ",t5.elapsed());

    var t6: Timer;
    t6.start();
    var D: domain(2) = {1..rows.size(), 1..rows.size()},
        SD = CSRDomain(D),
        X: [SD] real;
    t6.stop();
    writeln("Time to Initialize Base Matrix: ",t6.elapsed());

    var r = """
    SELECT source_cui, exhibited_cui
    FROM r.cui_confabulation
    ORDER BY source_cui, exhibited_cui ;
    """;


    var cursor2 = con.cursor();
    var t7: Timer;
    t7.start();
    cursor2.query(r);
    t7.stop();
    writeln("Time for Second DB Query: ",t7.elapsed());


    var t8: Timer;
    t8.start();
    var dom1: domain(1) = {1..0},
        dom2: domain(1) = {1..0},
        indices: [dom1] (int, int),
        values: [dom2] real;
    t8.stop();
    writeln("Time to Initialize Id/Val Arrays: ",t8.elapsed());

    var t9: Timer;
    t9.start();
    for row in cursor2 {
      indices.push_back((rows.get(row['source_cui']),rows.get(row['exhibited_cui'])));
    }
    t9.stop();
    writeln("Time to Push Back on Indices: ",t9.elapsed());



    var t10: Timer;
    t10.start();
    const size1 = cursor2.rowcount(): int;
    t10.stop();
    writeln("Cursor Length Read Time: ",t10.elapsed());

    var t11: Timer;
    t11.start();
    var count = 0: int,
        dom = {1..size1},
        indices1: [dom] (int, int),
        values1: [dom] real;
    t11.stop();
    writeln("Index/Value Array Initialization Time: ",t11.elapsed());

    var t12: Timer;
    t12.start();
    for row in cursor2 {
      count += 1;
      indices1[count]=(
         rows.get(row['source_cui'])
        ,rows.get(row['exhibited_cui'])
        );
      }
    t12.stop();
    writeln("Time to Graft Indices: ",t12.elapsed());

    var t13: Timer;
    t13.start();
    SD.bulkAdd(indices1);
    t13.stop();
    writeln("Time to bulkAdd Indices (~10^6) to Sparse Domain: ",t13.elapsed());

    var t14: Timer;
    t14.start();
    for (i,j) in indices {
      X(i,j) = 1;
    }
    t14.stop();
    writeln("Time to Graft Ones on to Base Matrix: ",t14.elapsed());


    var t15: Timer;
    t15.start();
    var nm = new NamedMatrix(X=X);
    nm.rows = rows;
    nm.cols = rows;
    t15.stop();
    writeln("Promoting X to NamedMatrix: ",t15.elapsed());
````
And following, an output sample:
````
./test/test -f ../db_creds.txt ; \
rm test/test

Please make sure your test database has been populated by the SQL script in
  test/reference/entropy_base_graph_schema.sql

Time to Establish Connection to the DB: 0.439924
Time to Create Cursor: 0.000286
Time to Initialize Rows BiMap: 1.3e-05
Time to Query the DB: 2.331
Time to Populate Rows BiMap: 4.27091
Time to Measure Length of Row BiMap: 0.0
Time to Initialize Base Matrix: 0.003699
Time for Second DB Query: 8.33702
Time to Initialize Id/Val Arrays: 8e-06
Time to Push Back on Indices: 40.0613
Cursor Length Read Time: 1e-06
Index/Value Array Initialization Time: 0.030447
Time to Graft Indices: 9.01305
Time to bulkAdd Indices (~10^6) to Sparse Domain: 3.17392
Time to Graft Ones on to Base Matrix: 0.905846
^CMakefile:20: recipe for target 'run-test' failed
make: *** [run-test] Interrupt
````